### PR TITLE
First pass at consolidating the config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,11 @@ The files in this directory represent the `eslint` configuration settings
 for Varnish.
 
 They're packaged as such so that they can be published as a separate NPM module,
-`@allenai/@allenai/eslint-config-varnish`. This allows them to be shared easily
+`@allenai/eslint-config-varnish`. This allows them to be shared easily
 across multiple AI2 projects.
 
 For more information about publishing and using shared `eslint` configuration
 definitions, see [this documentation](https://eslint.org/docs/user-guide/configuring).
-
-## Testing
-
-The configuration expressed in this directory is used by the parent project,
-so you can simply run `yarn lint` in the root of the repository to verify
-things are working.
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,48 @@ across multiple AI2 projects.
 For more information about publishing and using shared `eslint` configuration
 definitions, see [this documentation](https://eslint.org/docs/user-guide/configuring).
 
+## Usage
+
+Install it and it's peer dependencies:
+
+```shell
+~ yarn add @allenai/eslint-config-varnish \
+    @typescript-eslint/eslint-plugin \
+    @typescript-eslint/parser \
+    eslint \
+    eslint-config-prettier \
+    eslint-config-standard \
+    eslint-plugin-import \
+    eslint-plugin-node \
+    eslint-plugin-prettier \
+    eslint-plugin-promise \
+    eslint-plugin-react \
+    eslint-plugin-standard \
+    prettier
+```
+
+Create a file with patterns specifying stuff you'd like to ignore:
+
+```
+~ cat node_modules/ >> .eslintignore
+```
+
+Add targets for linting and reformatting code to your `package.json` file:
+
+```json
+"scripts": {
+    "lint": "eslint '**/*.{js,ts,tsx,json}' && echo '💫  Lint complete.'",
+    "lint:fix": "eslint '**/*.{js,ts,tsx,json}' --fix && echo '🛠  Lint --fix complete.'",
+}
+```
+
+Try it out:
+
+```json
+yarn lint
+yarn lint:fix
+```
+
 ## Publishing
 
 To publish a new version after making changes, follow these steps:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Install it and it's peer dependencies:
 Create a file with patterns specifying stuff you'd like to ignore:
 
 ```
-~ cat node_modules/ >> .eslintignore
+~ echo node_modules/ >> .eslintignore
 ```
 
 Add targets for linting and reformatting code to your `package.json` file:

--- a/README.md
+++ b/README.md
@@ -12,55 +12,63 @@ definitions, see [this documentation](https://eslint.org/docs/user-guide/configu
 
 ## Usage
 
-Install it and it's peer dependencies:
+1. Install it and it's peer dependencies:
 
-```shell
-~ yarn add @allenai/eslint-config-varnish \
-    @typescript-eslint/eslint-plugin \
-    @typescript-eslint/parser \
-    eslint \
-    eslint-config-prettier \
-    eslint-config-standard \
-    eslint-plugin-import \
-    eslint-plugin-node \
-    eslint-plugin-prettier \
-    eslint-plugin-promise \
-    eslint-plugin-react \
-    eslint-plugin-standard \
-    prettier
-```
+    ```shell
+    ~ yarn add @allenai/eslint-config-varnish \
+        @typescript-eslint/eslint-plugin \
+        @typescript-eslint/parser \
+        eslint \
+        eslint-config-prettier \
+        eslint-config-standard \
+        eslint-plugin-import \
+        eslint-plugin-node \
+        eslint-plugin-prettier \
+        eslint-plugin-promise \
+        eslint-plugin-react \
+        eslint-plugin-standard \
+        prettier
+    ```
 
-Create a file with patterns specifying stuff you'd like to ignore:
+2. Create a file with patterns specifying stuff you'd like to ignore:
 
-```
-~ echo node_modules/ >> .eslintignore
-```
+    ```bash
+    ~ cat <<EOF > .eslintignore
+    .next/
+    node_modules/
+    package.json
+    tsconfig.json
+    EOF
+    ```
 
-Create a config file, and configure `eslint` to use this package as a base:
+3. Create a config file, and configure `eslint` to use this package as a base:
 
-```bash
-cat <<EOF > .eslintrc.js
-module.exports = {
-   extends: [ "@allenai/eslint-config-varnish" ]
-};
-EOF
-```
+    ```bash
+    cat <<EOF > .eslintrc.js
+    module.exports = {
+    extends: [ "@allenai/eslint-config-varnish" ]
+    };
+    EOF
+    ```
 
-Add targets for linting and reformatting code to your `package.json` file:
+4. Add targets for linting and reformatting code to your `package.json` file:
 
-```json
-"scripts": {
-    "lint": "eslint '**/*.{js,ts,tsx,json}' && echo '💫  Lint complete.'",
-    "lint:fix": "eslint '**/*.{js,ts,tsx,json}' --fix && echo '🛠  Lint --fix complete.'",
-}
-```
+    ```json
+    "scripts": {
+        "lint": "eslint '**/*.{js,ts,tsx,json}' && echo '💫  Lint complete.'",
+        "lint:fix": "eslint '**/*.{js,ts,tsx,json}' --fix && echo '🛠  Lint --fix complete.'",
+    }
+    ```
 
-Try it out:
+5. Try it out:
 
-```json
-yarn lint
-yarn lint:fix
-```
+    ```bash
+    # See what's wrong
+    ~ yarn lint
+
+    # Reformat and fix things
+    ~ yarn lint:fix
+    ```
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Create a file with patterns specifying stuff you'd like to ignore:
 ~ echo node_modules/ >> .eslintignore
 ```
 
+Create a config file, and configure `eslint` to use this package as a base:
+
+```bash
+cat <<EOF > .eslintrc.js
+module.exports = {
+   extends: [ "@allenai/eslint-config-varnish" ]
+};
+EOF
+```
+
 Add targets for linting and reformatting code to your `package.json` file:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To publish a new version after making changes, follow these steps:
 ```bash
 ~ npm version major|minor|patch
 ~ git push --tags origin master
-~ npm publish
+~ npm publish --access public
 ```
 
 🤘 ⛵️ 🎨

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# eslint-config-varnish
-Common linting and formatter definitions for Varnish projects
+# ESLint Config
+
+The files in this directory represent the `eslint` configuration settings
+for Varnish.
+
+They're packaged as such so that they can be published as a separate NPM module,
+`@allenai/@allenai/eslint-config-varnish`. This allows them to be shared easily
+across multiple AI2 projects.
+
+For more information about publishing and using shared `eslint` configuration
+definitions, see [this documentation](https://eslint.org/docs/user-guide/configuring).
+
+## Testing
+
+The configuration expressed in this directory is used by the parent project,
+so you can simply run `yarn lint` in the root of the repository to verify
+things are working.
+
+## Publishing
+
+To publish a new version after making changes, follow these steps:
+
+```bash
+~ npm version major|minor|patch
+~ git push --tags origin master
+~ npm publish
+```
+
+🤘 ⛵️ 🎨

--- a/index.js
+++ b/index.js
@@ -1,0 +1,56 @@
+/**
+ * This file includes `eslint` settings that are distributed via the
+ * `@allenai/eslint-config-varnish` package and shared amongst many AI2
+ * projects.
+ *
+ * @see https://eslint.org/docs/user-guide/configuring
+ */
+module.exports = {
+    extends: [ "standard", "plugin:prettier/recommended" ],
+    env: {
+        browser: true,
+        es6: true
+    },
+    globals: {
+        Atomics: "readonly",
+        SharedArrayBuffer: "readonly"
+    },
+    parser: "@typescript-eslint/parser",
+    parserOptions: {
+        ecmaFeatures: {
+            jsx: true
+        },
+        sourceType: "module"
+    },
+    plugins: [
+        "react",
+        "@typescript-eslint",
+        "prettier"
+    ],
+    rules: {
+        "prettier/prettier": [
+            "error",
+            {
+                printWidth: 100,
+                tabWidth: 4,
+                singleQuote: true,
+                jsxBracketSameLine: true,
+                jsxSingleQuote: false
+            }
+        ],
+        "react/jsx-uses-react": 1,
+        "react/jsx-uses-vars": 1,
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": [
+            "error",
+            {
+                vars: "all",
+                args: "after-used",
+                ignoreRestSiblings: false,
+                argsIgnorePattern: "^_"
+            }
+        ],
+        "no-useless-constructor": "off",
+        "@typescript-eslint/no-useless-constructor": "error"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@allenai/eslint-config-varnish",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Common linting and formatting configuration for Varnish projects.",
   "main": "index.js",
   "repository": "https://github.com/allenai/varnish",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@allenai/eslint-config-varnish",
+  "version": "0.0.0",
+  "description": "Common linting and formatting configuration for Varnish projects.",
+  "main": "index.js",
+  "repository": "https://github.com/allenai/varnish",
+  "author": "REVIZ <reviz@allenai.org>",
+  "license": "Apache-2.0",
+  "private": false,
+  "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.3.1",
+    "@typescript-eslint/parser": "^2.3.1",
+    "eslint": "^6.5.1",
+    "eslint-config-prettier": "^6.3.0",
+    "eslint-config-standard": "^14.1.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-node": "^10.0.0",
+    "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-standard": "^4.0.1",
+    "prettier": "^1.18.2"
+  }
+}


### PR DESCRIPTION
This will allow us to use this config as such:

```
# .eslintrc.js
module.exports = {
   extends: [ "@allenai/eslint-config-varnish" ]
}
```

@jonborchardt Please review.