### PR TITLE
Don't be as restrictive about peer dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,19 +6,18 @@
   "repository": "https://github.com/allenai/varnish",
   "author": "REVIZ <reviz@allenai.org>",
   "license": "Apache-2.0",
-  "private": false,
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.3.1",
-    "@typescript-eslint/parser": "^2.3.1",
-    "eslint": "^6.5.1",
-    "eslint-config-prettier": "^6.3.0",
-    "eslint-config-standard": "^14.1.0",
-    "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-node": "^10.0.0",
-    "eslint-plugin-prettier": "^3.1.1",
-    "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-react": "^7.14.3",
-    "eslint-plugin-standard": "^4.0.1",
-    "prettier": "^1.18.2"
+    "@typescript-eslint/eslint-plugin": ">=2.3.1",
+    "@typescript-eslint/parser": ">=2.3.1",
+    "eslint": ">=6.5.1",
+    "eslint-config-prettier": ">=6.3.0",
+    "eslint-config-standard": ">=14.1.0",
+    "eslint-plugin-import": ">=2.18.2",
+    "eslint-plugin-node": ">=10.0.0",
+    "eslint-plugin-prettier": ">=3.1.1",
+    "eslint-plugin-promise": ">=4.2.1",
+    "eslint-plugin-react": ">=7.14.3",
+    "eslint-plugin-standard": ">=4.0.1",
+    "prettier": ">=1.18.2"
   }
 }


### PR DESCRIPTION
This updates the way we declare our peer dependencies so that
we merely ask that the user have *at least* the provided version
installed.

While there's some risk that there will be breaking changes in the
versions we allow, I think this is the right trade-off.

We don't often update this library, or assess it's compatibility
with the latest n' greatest. This means that a security-concious
user will be harassed by `yarn` or `npm` when being diligent and
updating their dependencies (if they happen to update one expresed
as a peer dependency here).

We've also seen in practice that this is likely ok, as we *have*
updated the depedencies this module relies upon and things have
continued to work without issue.

So, by doing this we *may* make an error when there is a breaking
change in one of these dependencies harder to catch -- but this is
likely a rare occurrence and in the meantime we'll encourage rather
than discourage updates.

Note, I did this as part of the work associated with this ticket:
https://github.com/allenai/skiff/issues/745